### PR TITLE
Added assert macros and test suites

### DIFF
--- a/guest
+++ b/guest
@@ -42,6 +42,10 @@
 (define tests (tokenize (assoc-ref args '())))
 (define cover-out (assoc-ref args 'cover-out))
 
+(define (realpath path)
+  (if (eqv? #\/ (string-ref path 0))
+      path (string-append (getcwd) "/" path)))
+
 (define (load-tests tests)
   (for-each
     (lambda (test)
@@ -49,7 +53,7 @@
         (lambda (filename statinfo flag)
           (when (and (eq? flag 'regular)
                      (string-match ".scm$" filename))
-            (load filename))
+            (load (realpath filename)))
           #t)))
     tests))
 

--- a/guest
+++ b/guest
@@ -49,7 +49,7 @@
         (lambda (filename statinfo flag)
           (when (and (eq? flag 'regular)
                      (string-match ".scm$" filename))
-            (load (string-append (getcwd) "/" filename)))
+            (load filename))
           #t)))
     tests))
 

--- a/printer.scm
+++ b/printer.scm
@@ -28,7 +28,7 @@
                          msg
                          (car err)
                          (apply format #f (cadr err) (caddr err))))
-            (#t (format #f "~a: ~s"
+            (#t (format #f "~a: ~a"
                         (bold (foreground #:red "fail"))
                         msg)))))
 

--- a/test.scm
+++ b/test.scm
@@ -37,7 +37,7 @@
   (define-test name tcase* ...)
   (set! *guest-tests*
     (atree-insert *guest-tests* (append suite-prefix (quote name))
-                  (λ ()
+                  (lambda ()
                     (call/cc
                       (lambda (cont)
                         (set! test-cont cont)

--- a/test.scm
+++ b/test.scm
@@ -10,14 +10,18 @@
 
 (define test-cont '())
 
-(define (assert-equal-internal? left right mleft mright)
+(define (assert-equal-internal? left right mleft mright cl)
  (unless (equal? left right)
-   (test-cont (cons #f (format #f "Left: ~A -> ~A != Right ~A -> ~A"
-                               mleft left mright right)))))
+   (test-cont (cons #f (format #f (string-append
+                                   "Left: ~A -> ~A != Right ~A -> ~A~%"
+                                   "On line ~A of ~A~%")
+                               mleft left mright right
+                               (cdr (assoc 'line cl))
+                               (cdr (assoc 'filename cl)))))))
 
 (define-syntax-rule
   (assert-equal? left right)
-  (assert-equal-internal? left right 'left 'right))
+  (assert-equal-internal? left right 'left 'right (current-source-location)))
 
 (define-syntax-rule
   (define-test name tcase* ...)

--- a/test.scm
+++ b/test.scm
@@ -24,7 +24,7 @@
 (define-syntax-rule
   (define-suite name rules* ...)
   (let ((copy suite-prefix))
-    (set! suite-prefix (append (quote name) suite-prefix))
+    (set! suite-prefix (append suite-prefix (quote name)))
     rules* ...
     (set! suite-prefix copy)))
 
@@ -41,8 +41,7 @@
                     (call/cc
                       (lambda (cont)
                         (set! test-cont cont)
-                        (return-fail tcase*)
-                        ...
+                        (return-fail tcase*) ...
                         #f))))))
 
 (define-syntax-rule

--- a/test.scm
+++ b/test.scm
@@ -2,6 +2,7 @@
   #:use-module (guest atree)
   #:use-module (srfi srfi-1)
   #:export (define-test
+            define-suite
             assert-equal?
             run-guest
             run-guest-test))
@@ -9,6 +10,8 @@
 (define *guest-tests* '())
 
 (define test-cont '())
+(define suite-prefix '())
+
 
 (define (assert-equal-internal? left right mleft mright cl)
  (unless (equal? left right)
@@ -18,6 +21,13 @@
                                mleft left mright right
                                (cdr (assoc 'line cl))
                                (cdr (assoc 'filename cl)))))))
+(define-syntax-rule
+  (define-suite name rules* ...)
+  (let ((copy suite-prefix))
+    (set! suite-prefix (append (quote name) suite-prefix))
+    rules* ...
+    (set! suite-prefix copy)))
+
 
 (define-syntax-rule
   (assert-equal? left right)
@@ -26,7 +36,7 @@
 (define-syntax-rule
   (define-test name tcase* ...)
   (set! *guest-tests*
-    (atree-insert *guest-tests* (quote name)
+    (atree-insert *guest-tests* (append suite-prefix (quote name))
                   (λ ()
                     (call/cc
                       (lambda (cont)


### PR DESCRIPTION
```
(define-suite (l1)
  (define-suite (l2)
    (define-test (a)
      (assert-equal? 2 (+ 1 1)))

    (define-test (b)
      (assert-equal? 1 (+ 1 2)))

    (define-test (c)
      (assert-equal? 2 (+ 1 1)))))

```
running this produces
```
Testing l1:
    Testing l2:
        test a: pass
        test b: fail: Left: 1 -> 1 != Right (+ 1 2) -> 3
On line 26 of testproject/test.scm

        test c: pass
    suite l1: ran 3, passed 2 (66.67%): fail

```
I did not touch any of guests tests though